### PR TITLE
chore: release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.4.2
+
+- Publish how-standards-evolve blog post
+- Expand and polish how-hard-can-email-be draft
+
 ## v1.4.1
 
 - Fix draft blog posts accidentally published

--- a/src/blog/how-hard-can-email-be/content.md
+++ b/src/blog/how-hard-can-email-be/content.md
@@ -6,25 +6,25 @@ Harder than it has any right to be. Here's what actually happens.
 
 ## How it started: paper and trust
 
-Before email, communication was physical. A letter required a stamp, an envelope, and a known address. Authentication came for free from the physics: a sealed envelope, a postmark, a signature. Tampering was detectable. If someone opened your letter, the seal was broken. If someone forged your handwriting, it was detectable with effort. The system wasn't secure in any modern sense, but it had natural properties that made it surprisingly robust. Trust was built into the medium.
+Before email, communication was physical. A letter required a stamp, an envelope, and a known address. Authentication came for free from the physics: a sealed envelope, a postmark, a signature. Tampering was detectable. If someone opened your letter, the seal was broken. If someone forged your handwriting, it was detectable with effort. The system wasn't secure in any modern sense, but it had natural properties that made it surprisingly robust.
 
-There was no spam because sending a letter cost money. There was no spoofing at scale because forging thousands of letters required physical effort. There was no interception at scale because it required physical access. The constraints of paper were also its security model.
+There was no spam because sending a letter cost money. There was no spoofing at scale because forging thousands of letters required physical effort. There was no interception at scale because it required physical access. The physics of paper did what protocols would later have to do deliberately.
 
 ## Email's original sin
 
-SMTP - the protocol that moves email between servers - was designed in 1982. The internet was a network of trusted universities and research institutions. The people using it knew each other. Spam wasn't a concept. Spoofing wasn't a concern. The assumption was: if you're on this network, you're probably legitimate.
+SMTP - the protocol that moves email between servers - was designed in 1982. The internet was a network of trusted universities and research institutions. The people using it knew each other. A Nigerian prince hadn't yet discovered how much cheaper email was than fax for extracting $700,000 a year from strangers. The assumption was: if you're on this network, you're probably legitimate.
 
-So SMTP was designed for that world. To send an email, you open a TCP connection to a server, say HELO, hand over a message, and disconnect. That's it. No authentication. No encryption. No verification that the sender is who they claim to be. The simplicity wasn't a mistake - it was appropriate for the problem at the time.
+So SMTP was designed for that world. To send an email, you open a TCP connection to a server, say HELO, hand over a message, and disconnect. That's it. No authentication. No encryption. No verification that the sender is who they claim to be. The simplicity wasn't a mistake - it was appropriate for the problem at the time. It also assumed servers could be offline - messages would be held and retried until delivery succeeded, sometimes days later.
 
-But the internet grew, and the assumptions didn't.
+The internet outgrew it.
 
 ## The patches
 
-Every abuse that followed produced a new specification. Each one solved a real problem. Each one is now mandatory if you want your email to arrive.
+Every abuse that followed produced a new specification - and every one of them is now mandatory if you want your email to arrive.
 
 **Spam.** As email became universal, so did unsolicited bulk mail. The response was reputation systems: blacklists, spam filters, heuristic scoring. But reputation is hard to bootstrap. A new IP address with no history is suspicious by default. You can do everything right and still have your email land in spam for weeks because your server is "unknown."
 
-**Spoofing.** SMTP lets anyone claim to be anyone. I can send an email that says it's from president@whitehouse.gov. Nothing in the original protocol stops this. SPF (2006) was the first real answer: a DNS record that says which IP addresses are allowed to send mail for a domain. If the sending IP isn't on the list, receivers can reject or mark the message.
+**Spoofing.** SMTP lets anyone claim to be anyone. I can send an email that says it's from <president@whitehouse.gov>. Nothing in the original protocol stops this. SPF (2006) was the first real answer: a DNS record that says which IP addresses are allowed to send mail for a domain. If the sending IP isn't on the list, receivers can reject or mark the message.
 
 **Tampering.** SPF verifies the sending server but not the message content. DKIM (2007) adds a cryptographic signature to each email, signed with a private key the sender controls. Receivers check the signature against a public key published in DNS. If the signature doesn't match, the message was altered in transit.
 
@@ -34,26 +34,34 @@ Every abuse that followed produced a new specification. Each one solved a real p
 
 **Clients.** SMTP moves mail between servers. IMAP lets clients read it. CalDAV syncs calendars. CardDAV syncs contacts. If you want users to connect with Thunderbird, Apple Mail, or Outlook, you need all of these. Each is a separate protocol, a separate service, a separate thing to configure, secure, and maintain.
 
-This is the answer to "how hard can it be?" Seven protocols, all mandatory, each introduced to patch a gap in the previous ones.
+**Push.** IMAP is poll-based - clients ask the server if anything is new. Modern clients expect the server to push notifications instead. IMAP IDLE is the open standard for this. Exchange ActiveSync is the proprietary alternative that much of the ecosystem has standardized on in practice. Mobile push adds another layer: iOS and Android each have their own notification infrastructure, and neither speaks IMAP directly.
+
+Many patches, all mandatory, each introduced to fill a valid serious gap. That's the answer to "how hard can it be?"
 
 ## Self-hosting in 2026
 
 If you want to run your own mail server today, here's what you need:
 
 - A domain with correct MX, A, and PTR records
-- An MTA (Postfix, Exim, or similar) for sending and receiving
+- A mail server for sending and receiving
 - SPF, DKIM, and DMARC records configured correctly in DNS
-- A DKIM signing setup tied to your MTA
+- A DKIM signing setup tied to your mail server
 - STARTTLS with a valid TLS certificate
 - MTA-STS policy published
-- An IMAP server (Dovecot is the standard choice)
+- An IMAP server, plus push notification support if you want clients to receive mail in real time
+- Storage, archival, and backup for all mail
+- A spam filter with a quarantine - plus a way for users to report spam and to un-flag false positives
+- Your own spam heuristics, because no off-the-shelf filter knows your users
 - A CalDAV/CardDAV server if you want calendar and contacts sync
 - An IP address with a clean reputation history
 - Ongoing monitoring for blacklist listings
+- Password policy enforcement and rotation
+- TLS certificate rotation before expiry
+- PGP/GPG support if you want E2E encryption - accepting that most recipients won't have it, so most mail stays unencrypted anyway
 
 One misconfigured DNS record and your email lands in spam. One IP with a history of abuse and you're blocked before you've sent a single message. Major providers - Gmail, Outlook - apply their own heuristics on top of all of this, and they don't publish them. You can pass every test and still fail their filters.
 
-This is why almost nobody self-hosts email anymore. Not because it's impossible - it isn't - but because the cost of maintaining a good reputation on a shared global infrastructure is ongoing and unpredictable. In practice, the "decentralized" email network runs on three providers.
+This is why almost nobody self-hosts email anymore. Maintaining a good reputation on a shared global infrastructure is ongoing and unpredictable work, and the penalty for getting it wrong is silence - your email just stops arriving. In practice, the "decentralized" email network runs on three providers.
 
 ## The missing patch: end-to-end encryption
 
@@ -67,10 +75,16 @@ Metadata. Even with encrypted content, email leaks: who you're writing to, when,
 
 Spam filtering. Encrypted content can't be inspected. Providers who filter spam on the server side - which is all of them - resist encryption because it breaks their filters. Tutanota and Proton Mail solved this by controlling both ends of the conversation. Between their own users, they can encrypt everything. With the rest of the world, they fall back to standard SMTP and TLS.
 
-The result is that E2E encrypted email, at scale, across providers, remains effectively unsolved after 35 years. Every serious attempt has either required both parties to use the same provider, or has imposed key management on users that they won't accept.
+E2E encrypted email, at scale, across providers, remains unsolved after 35 years. Every serious attempt has either required both parties to use the same provider, or has imposed key management on users that they won't accept.
+
+## Why it's still here
+
+None of this stopped email from winning. Official correspondence is still migrating from paper to email. Everyone has at least one address, the same way everyone used to have a postal address. It's the universal fallback - the one channel you can reach anyone on when you don't share a platform.
+
+Email does the job. It's ugly, it accreted rather than designed, and running your own is a project, not an afternoon. Even getting a clean IP address is harder than it sounds: IPv4 exhaustion means most available addresses have a history, and that history comes with a reputation you didn't earn and may spend months repairing.
 
 ## Where email ends
 
-Some of these problems can't be patched. E2E encryption at scale, metadata privacy, clean group semantics - they conflict with the assumptions SMTP was built on. The protocol's constraints aren't in the configuration. They're in the foundations.
+Some of these problems can't be patched. E2E encryption at scale, metadata privacy, clean group semantics - they conflict with the assumptions SMTP was built on. The constraints aren't in the configuration. They're in the foundations.
 
 Which is why some people stopped patching and started over. That's a different story - one about what "sending a message" actually requires, what email got right and wrong, and whether the reinvention was worth it.

--- a/src/blog/how-hard-can-email-be/meta.yaml
+++ b/src/blog/how-hard-can-email-be/meta.yaml
@@ -1,3 +1,3 @@
 title: How hard can it be?
-date: "2026-07-01"
+date: "2026-08-01"
 publish: false

--- a/src/blog/how-standards-evolve/content.md
+++ b/src/blog/how-standards-evolve/content.md
@@ -2,64 +2,92 @@
 
 <!-- DRAFT - notes and sections to explore, not yet polished prose -->
 
-Standards solve coordination problems. But the process of making and maintaining them creates its own coordination problems. That tension is worth understanding - because the way we govern standards today has real consequences for who controls the technology everyone depends on.
+Standards solve coordination problems. But the process of making and maintaining them creates its own coordination problems - and the way we govern standards today determines who controls the technology everyone depends on.
 
 ## The landscape
 
-The internet and the web are held together by a loose federation of standards bodies, each with different scope, culture, and governance:
+The internet and the web are held together by a loose federation of standards bodies, each with different scope, culture, and governance. They overlap, compete, and occasionally coordinate - sometimes standardizing the same technology with subtle incompatibilities between versions.
 
-- **IETF** (Internet Engineering Task Force) - internet protocols: TCP/IP, HTTP, SMTP, DNS, TLS. Famous for "rough consensus and running code" - a standard only advances if there are working implementations.
-- **W3C** (World Wide Web Consortium) - web standards: HTML, CSS, WebAssembly, accessibility. Membership-based, slow and deliberate.
-- **IEEE** (Institute of Electrical and Electronics Engineers) - networking hardware and electrical standards: Wi-Fi (802.11), Ethernet (802.3).
-- **ISO** - international meta-standard body. Ratifies standards from others (e.g. PDF, MPEG formats, the metric system). Slow, bureaucratic, but globally recognized.
-- **ECMA International** - JavaScript (ECMAScript), JSON, Office Open XML.
-- **OASIS** - enterprise and web services standards: SAML, MQTT, OpenDocument.
-
-These bodies overlap, compete, and occasionally coordinate. The same technology can end up standardized by multiple bodies at once, with subtle incompatibilities between versions.
+- **IETF** (Internet Engineering Task Force) - internet protocols (HTTP, QUIC). Famous for "rough consensus and running code" - a standard only advances if there are working implementations.
+- **W3C** (World Wide Web Consortium) - web standards (HTML, WebAssembly). Membership-based, slow and deliberate.
+- **IEEE** (Institute of Electrical and Electronics Engineers) - networking hardware and electrical standards (Ethernet 802.3, Wi-Fi 6 802.11ax).
+- **ISO** - international meta-standard body. Ratifies standards from other bodies (metric system, PDF). Slow, bureaucratic, but globally recognized.
+- **ECMA International** - programming language and data format standards (JavaScript/ECMAScript, JSON).
+- **OASIS** - enterprise and web services standards (SAML, MQTT).
 
 ## The power problem
 
 Standards bodies are formally neutral. In practice, they're funded and staffed by the companies that have the most to gain from the outcome.
 
-W3C membership fees run from a few thousand dollars for small organizations to over $80,000 per year for large ones - and large companies don't just pay, they send full-time employees to working groups. A company like Google or Apple might have dozens of engineers actively shaping specs. A small browser vendor or academic institution has one person, part-time.
+W3C membership fees run from a few thousand dollars for small organizations to over $80,000 per year for large ones - and large companies don't only pay, they send full-time employees to working groups. A company like Google or Apple might have dozens of engineers shaping specs. A small browser vendor or academic institution has one person, part-time.
 
-This matters because the annual revenue of the companies at the table now dwarfs the GDP of many countries. Apple's revenue (~$400B) exceeds the GDP of countries like Denmark or Portugal. Google's parent company clears over $300B. When companies at that scale have a financial interest in the outcome of a spec, "consensus" becomes a complicated word.
+The annual revenue of the companies at the table now dwarfs the GDP of many countries. Apple's revenue (~$400B) exceeds the GDP of Denmark or Portugal. Google's parent company clears over $300B. When companies at that scale have a stake in the outcome of a spec, "consensus" becomes a complicated word.
 
-The result is that standards increasingly reflect what large implementers are willing to ship, rather than what the broader ecosystem needs. A feature that Google deprioritizes tends not to advance. A feature that Apple objects to tends not to land on iOS - regardless of what the spec says.
+Standards reflect what large implementers will ship, not what the broader ecosystem needs. A feature Google deprioritizes tends not to advance. A feature Apple objects to tends not to land on iOS - regardless of what the spec says.
 
 ## Where it went wrong - examples to explore
 
-### Microsoft OOXML vs ODF (2006-2008)
+### ISO/OSI model
 
-The clearest case of standards process capture. OpenDocument Format (ODF) was an open ISO standard for office documents. Microsoft pushed their own format - OOXML - through ISO, reportedly pressuring national standards bodies to vote in its favor, including allegations of last-minute membership stacking in several countries. OOXML passed. The world ended up with two competing ISO-ratified document format standards. Microsoft still controls OOXML. ODF remains open but fragmented across implementations.
+In the 1970s and 80s, ISO developed the OSI (Open Systems Interconnection) model - a seven-layer networking architecture designed by committee to be the universal standard for computer networking. It was theoretically rigorous, carefully structured, and backed by major governments and telecoms who mandated it for public procurement.
 
-### The WHATWG split (2004-2019)
+TCP/IP had none of that. It emerged from ARPANET research, was never formally standardized by any recognized body, and was designed around working implementations rather than architectural purity. By the time OSI was ready to deploy, TCP/IP already ran the internet.
 
-W3C was developing XHTML 2.0 - a clean, strict version of HTML that was theoretically better but ignored the billions of existing pages that didn't conform to it. Browser vendors (Apple, Mozilla, Opera) concluded W3C was moving in the wrong direction and formed the WHATWG, which began developing HTML5 in parallel. For years there were two competing HTML specs. W3C eventually adopted HTML5 and wound down XHTML 2.0, but only after years of confusion. The lesson: when the standards body loses touch with implementers, implementers leave and form their own.
-
-### CSS vendor prefixes
-
-Before CSS properties were standardized, browsers implemented them under vendor prefixes: `-webkit-`, `-moz-`, `-ms-`, `-o-`. The intent was to let browsers experiment before committing to a spec. The result was that web developers had to write the same declaration four times, and many sites only tested with `-webkit-`, locking them into Chrome/Safari behavior. The prefix experiment created a de facto standard (WebKit) within the formal standardization process. It took years to clean up.
-
-### Video codec wars
-
-H.264 is covered by patents held by a pool of companies who charge licensing fees. Google responded by acquiring On2 and releasing VP8/VP9 as royalty-free alternatives. Mozilla, Opera, and others backed them. The result: years of browser fragmentation, content creators having to encode multiple formats, and streaming services picking sides. AV1 eventually emerged as a genuinely open successor, but only after a decade of waste. The patent system and the standardization process pulled in opposite directions.
+OSI lost not because it was worse on paper, but because it arrived too late with too much complexity and too little running code. The lesson: a theoretically superior standard that nobody ships is not a standard. Real-world deployment beats architectural elegance every time.
 
 ### Embrace, extend, extinguish
 
-Microsoft's strategy in the late 1990s: implement an open standard, add proprietary extensions that only work in Internet Explorer, then market the extensions until the web de facto depends on them. ActiveX, DHTML, and IE-specific CSS behaviors were all examples. The open standard survived, but the ecosystem fractured. The strategy only failed when Firefox (and later Chrome) rebuilt market share behind genuinely open implementations.
+Microsoft's strategy in the late 1990s browser wars: implement an open standard, add proprietary extensions that only work in Internet Explorer, then market the extensions until the web depends on them. ActiveX, DHTML, and IE-specific CSS behaviors were all examples. The open standard survived, but the ecosystem fractured. The strategy only failed when Firefox (and later Chrome) rebuilt market share behind genuinely open implementations. The lesson: open standards are only as open as the dominant implementation. A spec nobody else can match in practice is proprietary lock-in with extra steps.
 
-### Google AMP
+### The WHATWG split (2004-2019)
 
-More recent and subtler. Google's Accelerated Mobile Pages was a restricted subset of HTML that Google would preferentially serve and rank in search results. It wasn't a formal standard - it was a de facto one enforced through search market share. Publishers who didn't implement AMP were penalized in rankings. AMP effectively gave Google editorial control over web page structure under the guise of performance. It's being wound down now, but for several years it demonstrated how a company with enough market power can bypass standards bodies entirely.
+W3C was developing XHTML 2.0 - a clean, strict version of HTML that was theoretically better but ignored the billions of existing pages that didn't conform to it. Browser vendors (Apple, Mozilla, Opera) concluded W3C was moving in the wrong direction. They formed the WHATWG, which began developing HTML5 in parallel. For years there were two competing HTML specs. W3C eventually adopted HTML5 and wound down XHTML 2.0, but only after years of confusion. The lesson: when the standards body loses touch with implementers, implementers leave and form their own.
+
+### Microsoft OOXML vs ODF (2006-2008)
+
+The clearest case of standards process capture.
+
+Some background: `.doc` was Microsoft's old binary format - proprietary, undocumented, reverse-engineered by everyone else. In 2007 Microsoft introduced `.docx` (and `.xlsx`, `.pptx`), built on OOXML - Office Open XML, a ZIP archive of XML files. ODF - OpenDocument Format - was the competing open standard, backed by Sun, IBM, and the OpenOffice project, native to OpenOffice and LibreOffice.
+
+The compatibility hell people remember from mixing Word and OpenOffice files had two layers: implementing the undocumented `.doc` binary format was imperfect, and implementing OOXML was worse. The spec ran to roughly 6000 pages and was riddled with Windows-specific and legacy-Office-specific behaviors that were impossible to implement outside Microsoft's own toolchain.
+
+That context is why the standards fight mattered: governments and enterprises were moving toward mandating open formats for public documents. Whoever won "official open standard" status would determine whether the future was interoperable.
+
+Microsoft pushed OOXML through ISO. The process was [extensively documented](https://en.wikipedia.org/wiki/Standardization_of_Office_Open_XML): Sweden invalidated its vote after one company cast multiple ballots; Norway's technical committee voted majority against but the administration overrode them to approve (13 of 23 committee members resigned in protest); the European Commission opened an antitrust investigation in January 2008. OOXML passed. The world ended up with two competing ISO-ratified document format standards. Microsoft still controls OOXML. ODF remains open but fragmented across implementations.
+
+The lesson: an "open" standard that depends on proprietary components - legacy Windows behaviors, undocumented Office internals - is a proprietary standard. The openness is in the XML wrapper, not the spec.
+
+### CSS vendor prefixes
+
+Before CSS properties were standardized, browsers implemented them under vendor prefixes: `-webkit-`, `-moz-`, `-ms-`, `-o-`. The intent was to let browsers experiment before committing to a spec. The result was that web developers had to write the same declaration four times, and many sites only tested with `-webkit-`, locking them into Chrome/Safari behavior. The prefix experiment created a de facto standard (WebKit) within the formal standardization process.
+
+Most prefixed properties were eventually standardized and the prefixes deprecated - but some remain. `-webkit-appearance` and `-webkit-scrollbar` are still required in 2024 for cross-browser consistency, because Chrome and Safari's market share made their prefixed behavior the de facto standard before any unprefixed version landed.
+
+When the vendor with dominant market share ships a prefix, the prefix becomes the de facto standard - forcing others to support it too. But without a proper spec, every browser builds their own interpretation. You end up with one name for several subtly incompatible behaviors.
+
+The lesson: don't wait too long to standardize experimental features. Leave the window open long enough and the market leader shapes it however suits them, and everyone else spends years catching up to a moving target.
+
+### H.265 / HEVC
+
+H.264 is covered by patents held by a pool of companies who charge licensing fees. H.265 (HEVC) - the technical successor, roughly twice the compression efficiency - made things worse. Three separate patent pools formed around it (MPEG LA, HEVC Advance, Velos Media), with no coordinated licensing terms and fees that streaming services found unpredictable. Apple adopted it across their ecosystem; hardware decoders shipped on most devices by ~2015. But browser vendors stayed away - Chrome didn't ship H.265 decode until 2022, Firefox support remains limited - because patent uncertainty made adoption legally risky at scale.
+
+Technically superior, commercially abandoned. The lesson: rights need to be clarified before a standard is widely adopted, not after. A standard with unresolved or competing patent claims isn't open - it's proprietary with a delay fuse. By the time the ecosystem discovers the terms are unusable, adoption stops and everyone waits for something else.
 
 ### Bluetooth codec fragmentation
 
 SBC is the baseline Bluetooth audio codec - open, low quality. aptX (Qualcomm-owned, licensed), AAC (Apple-preferred), LDAC (Sony), LC3 (the new standard). Every Android phone supports a different combination. Every pair of headphones works perfectly with some devices and not others. The "universal" wireless audio standard is anything but. No one body coordinates it, and every major player has an incentive to push their own format.
 
+Two lessons here. First: extensions to a standard - proprietary or even open - that never get folded back into an official new version are still proprietary standards. aptX and LDAC are both "supported" and both lock you into a specific vendor pair. The base standard exists; everything above it is fragmentation dressed as a feature.
+
+Second: waiting too long to standardize extensions guarantees that outcome. LC3 arrived in 2020, by which point the ecosystem had already calcified around incompatible proprietary codecs. Each vendor had too much invested to abandon their format for a late-arriving open one.
+
+### Google AMP
+
+More recent and subtler. Google's Accelerated Mobile Pages was a restricted subset of HTML that Google would serve and rank ahead of everything else. It wasn't a formal standard - it was a de facto one enforced through search market share. Publishers who didn't implement AMP were penalized in rankings. AMP gave Google editorial control over web page structure under the guise of performance. It's being wound down now, but for several years it showed how a company with enough market power can bypass standards bodies entirely. The lesson: you don't need anyone to approve your standard if you control the consumer.
+
 ## The "15 standards" problem
 
-There's an XKCD comic about this. Someone looks at 14 competing standards and says: "This is ridiculous. There should be one universal standard." There are now 15 standards.
+There's an [XKCD comic about this](https://xkcd.com/927/). Someone looks at 14 competing standards and says: "This is ridiculous. There should be one universal standard." There are now 15 standards.
 
 The joke is accurate. The instinct to unify creates the very proliferation it tries to solve, because:
 
@@ -72,28 +100,54 @@ This isn't an argument against standardization. It's an argument against the ass
 
 ## What has actually worked
 
-### IETF's "rough consensus and running code"
+### TCP/IP
 
-Don't standardize a design. Standardize implementations that already interoperate. This forces the spec to reflect reality rather than aspiration. HTTP/1.1, TLS 1.3, and QUIC all went through this process. It's slower to start but produces standards that actually work.
+TCP/IP won against OSI by doing the opposite: it shipped. ARPANET had running implementations before anyone wrote a formal spec. When the IETF eventually codified the process, it named it "rough consensus and running code" - don't standardize a design, standardize implementations that already interoperate.
+
+The lesson carried forward: HTTP/1.1, TLS 1.3, and QUIC all went through the same process. A spec that reflects working code is harder to break than one that reflects committee intent.
 
 ### Living standards
 
-WHATWG's response to the waterfall model of standards. HTML is now a "living standard" - continuously updated, no version numbers, with browsers implementing features as they land. This trades snapshot clarity for continuous relevance. It works because the implementers are also the authors. It wouldn't work for standards that need third-party interoperability.
+WHATWG's response to the waterfall model of standards. HTML is now a "living standard" - continuously updated, no version numbers, with browsers implementing features as they land. This trades snapshot clarity for continuous relevance. It works because the implementers are also the authors. It wouldn't work for standards that require third-party interoperability.
 
 ### Modular specs
 
 CSS moved from a monolithic spec to independent modules (CSS Grid, CSS Variables, CSS Flexbox) each on its own timeline. This means a working group can ship Flexbox without waiting for the entire CSS specification to stabilize. The tradeoff is complexity in knowing which modules are at which level of maturity.
 
-## How to improve it - directions to explore
+### AV1
 
-- **Separating funding from voting power.** Tiered membership where companies can fund the body without that funding translating directly into spec influence. Hard to implement without someone to enforce it.
+AV1 emerged directly from the H.265 failure. The Alliance for Open Media (Google, Mozilla, Microsoft, Apple, Netflix, Amazon, and others) built a royalty-free codec designed to route around the HEVC licensing impasse. Compression efficiency is roughly on par with H.265, with further gains at higher encode settings. Hardware decode is widespread; hardware encode arrived in consumer GPUs around 2022 and is catching up fast.
 
-- **Mandatory implementation before ratification.** Extend the IETF model more broadly. A spec that nobody has shipped in a working form shouldn't be a standard.
+The lesson: when rights are settled upfront and the major implementers are also the authors, a standard can ship. AV1 did what H.265 couldn't - not because the technology was better organized, but because the licensing was.
 
-- **Antitrust attention on standards processes.** When a company with 90%+ browser market share shapes web standards, that's a competition issue as much as a technical one. EU Digital Markets Act is beginning to touch this.
+## Open problems
 
-- **Clear deprecation paths.** Standards accumulate because old ones never die. If a standard had a built-in sunset clause - adopted when a better replacement reaches a certain maturity - the ecosystem would be less cluttered.
+### Entrenched fragmentation
 
-- **Reference implementations as part of the spec.** If the standard ships with a canonical open-source implementation, the gap between spec and reality closes. Reduces the "compliant but incompatible" problem.
+Once fragmentation calcifies, formal standards arrive too late to matter. LC3 is the correct open Bluetooth audio codec - but aptX and LDAC aren't going anywhere. Every major vendor has hardware, firmware, and marketing invested in their format. The open standard won on paper and lost in the market.
 
-- **Smaller scope, faster cycle.** The bigger the standard, the longer it takes, the more it gets captured. Breaking problems into the smallest independently-useful pieces reduces both capture risk and implementation debt.
+A few directions: hardware certification bodies (like Wi-Fi Alliance for Wi-Fi) could phase out certification for fragmented proprietary codecs over a defined timeline. Government procurement could mandate the base standard - if public contracts require LC3 support, device makers have a reason to prioritize it. Neither is fast, but the alternative is waiting for the market to self-correct, which it demonstrably won't.
+
+### Funding buys influence
+
+Working group participation scales with company size. Google and Apple each have dozens of full-time engineers shaping web specs; a small browser vendor or academic institution has one person, part-time. The formal voting process is neutral; the actual drafting is not.
+
+Separating funding tiers from voting weight is the obvious fix - companies can sustain the body financially without that translating into spec control. Rotating technical chairs and independent editors (the model WHATWG uses) reduce the effect further. Hard to retrofit onto bodies where the large members are also the funders, but newer bodies can choose it from the start.
+
+### Patent ambush
+
+A standard advances, reaches widespread adoption, then patent holders surface with incompatible licensing demands - or, as with H.265, multiple competing pools form after the fact. By then switching costs are too high to walk away.
+
+W3C already has a working answer: royalty-free licensing is a condition of inclusion in a web standard. Patent holders who want their technology in the spec must commit to license it royalty-free, upfront. Extending that norm to other bodies - and requiring disclosure of known patents before ratification, not after - would close most of the gap. H.265 would have looked different under those rules.
+
+### Standards that never die
+
+IPv6 has existed since 1998. IPv4 is still the default in 2024. Old standards don't die when better replacements arrive - they accumulate, and implementers must support both indefinitely.
+
+Built-in sunset clauses could help: once a replacement reaches a defined maturity threshold (say, two major independent implementations passing a shared test suite), the old standard enters a deprecation window with a real end date, not an advisory one. The EU's USB-C mandate is a blunt version of this - regulation forcing deprecation when market incentives won't. That's a last resort, but it worked.
+
+### De facto standards bypass the process entirely
+
+AMP didn't go through any standards body - Google had enough search market share to mandate it unilaterally. More recently, OpenAI's API has become a de facto standard that competing model providers implement for compatibility, not because anyone agreed it should be.
+
+Antitrust scrutiny on standards-through-market-power is increasing - the EU Digital Markets Act is beginning to require interoperability from gatekeepers. But regulation lags years behind deployment. The faster check is interoperability requirements baked into platform designation: if you control the distribution channel, you don't also get to control the format.

--- a/src/blog/how-standards-evolve/meta.yaml
+++ b/src/blog/how-standards-evolve/meta.yaml
@@ -1,3 +1,2 @@
 title: How standards evolve
-date: "2026-06-01"
-publish: false
+date: "2026-07-01"

--- a/src/blog/sending-a-message/meta.yaml
+++ b/src/blog/sending-a-message/meta.yaml
@@ -1,3 +1,3 @@
 title: Sending a message
-date: "2026-08-01"
+date: "2026-09-01"
 publish: false

--- a/src/blog/the-decentralized-web/meta.yaml
+++ b/src/blog/the-decentralized-web/meta.yaml
@@ -1,3 +1,3 @@
 title: The decentralized web
-date: "2026-07-01"
+date: "2026-10-01"
 publish: false


### PR DESCRIPTION
## Summary

- Publish how-standards-evolve blog post
- Expand and polish how-hard-can-email-be draft (push protocol, IPv4 reputation, E2E limitations, prose cleanup)
- Update CHANGELOG for v1.4.2